### PR TITLE
Set entity _attr_alarm_state instead of overloaded _state

### DIFF
--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -36,7 +36,6 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
         self._hkc_alarm = data.get('hkc_alarm')
         self._scan_interval = data.get('scan_interval')
         self._device_info = device_info
-        self._state = None
         self._panel_data = None
 
     @property
@@ -73,10 +72,6 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
         }
 
     @property
-    def state(self):
-        return self._state
-
-    @property
     def name(self):
         return "HKC Alarm System"
 
@@ -109,15 +104,15 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
         blocks = status.get("blocks", [])
 
         if any(block["inAlarm"] for block in blocks):
-            self._state = "triggered"
+            self._attr_state = "triggered"
         elif any(block["armState"] == 3 for block in blocks):
-            self._state = "armed_away"
+            self._attr_state = "armed_away"
         elif any(block["armState"] == 2 for block in blocks):
-            self._state = "armed_night"
+            self._attr_state = "armed_night"
         elif any(block["armState"] == 1 for block in blocks):
-            self._state = "armed_home"
+            self._attr_state = "armed_home"
         else:
-            self._state = "disarmed"
+            self._attr_state = "disarmed"
 
         self.async_write_ha_state()  # Update the state with the latest data
 

--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -1,8 +1,7 @@
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntity
-from .const import DOMAIN
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
 )
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -104,15 +103,15 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
         blocks = status.get("blocks", [])
 
         if any(block["inAlarm"] for block in blocks):
-            self._attr_state = "triggered"
+            self._attr_alarm_state = AlarmControlPanelState.TRIGGERED
         elif any(block["armState"] == 3 for block in blocks):
-            self._attr_state = "armed_away"
+            self._attr_alarm_state = AlarmControlPanelState.ARMED_AWAY
         elif any(block["armState"] == 2 for block in blocks):
-            self._attr_state = "armed_night"
+            self._attr_alarm_state = AlarmControlPanelState.ARMED_NIGHT
         elif any(block["armState"] == 1 for block in blocks):
-            self._attr_state = "armed_home"
+            self._attr_alarm_state = AlarmControlPanelState.ARMED_HOME
         else:
-            self._attr_state = "disarmed"
+            self._attr_alarm_state = AlarmControlPanelState.DISARMED
 
         self.async_write_ha_state()  # Update the state with the latest data
 


### PR DESCRIPTION
Set entity _attr_alarm_state using AlarmControlPanelState enum instead of _state defined in parent Entity class.